### PR TITLE
ESC-230 fixes to storage of non-hmrc subsidies

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancestub/models/UndertakingSubsidies.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/models/UndertakingSubsidies.scala
@@ -31,5 +31,17 @@ case class UndertakingSubsidies(
 
 // TODO reinstate (and remove one in json.eis if subsidyUsageTransactionID case can be aligned in SCP06 & 09
 object UndertakingSubsidies {
+
   implicit val format: Format[UndertakingSubsidies] = Json.format[UndertakingSubsidies]
+
+  def emptyInstance(identifier: UndertakingRef) = UndertakingSubsidies(
+    undertakingIdentifier = identifier,
+    nonHMRCSubsidyTotalEUR = SubsidyAmount(0),
+    nonHMRCSubsidyTotalGBP = SubsidyAmount(0),
+    hmrcSubsidyTotalEUR = SubsidyAmount(0),
+    hmrcSubsidyTotalGBP = SubsidyAmount(0),
+    nonHMRCSubsidyUsage = List.empty,
+    hmrcSubsidyUsage = List.empty,
+  )
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancestub/services/EisService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/services/EisService.scala
@@ -16,11 +16,19 @@
 
 package uk.gov.hmrc.eusubsidycompliancestub.services
 
-import uk.gov.hmrc.eusubsidycompliancestub.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancestub.models.types.Sector.Sector
+import uk.gov.hmrc.eusubsidycompliancestub.models.types.{EORI, IndustrySectorLimit, Sector, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancestub.models.{SubsidyRetrieve, Undertaking, UndertakingSubsidies}
 import uk.gov.hmrc.smartstub._
 
 object EisService {
+
+  private val SectorLimits = Map[Sector, IndustrySectorLimit](
+    Sector.agriculture -> IndustrySectorLimit(30000),
+    Sector.aquaculture -> IndustrySectorLimit(20000),
+    Sector.other -> IndustrySectorLimit(200000),
+    Sector.transport -> IndustrySectorLimit(100000),
+  )
 
   implicit class RichEORI(in: EORI) {
     def toLong: Long = in.substring(2).toLong
@@ -30,7 +38,7 @@ object EisService {
     val madeUndertaking = retrieveUndertaking(eori)
     val merged = undertaking.copy(
       reference = madeUndertaking.reference,
-      industrySectorLimit = madeUndertaking.industrySectorLimit,
+      industrySectorLimit = SectorLimits.get(undertaking.industrySector),
       lastSubsidyUsageUpdt = madeUndertaking.lastSubsidyUsageUpdt
     )
     merged

--- a/app/uk/gov/hmrc/eusubsidycompliancestub/services/JsonSchemaChecker.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/services/JsonSchemaChecker.scala
@@ -22,7 +22,6 @@ import com.github.fge.jsonschema.core.report.ProcessingReport
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import play.api.Logger
 import play.api.libs.json.{Format, Json}
-import scala.collection.JavaConverters._
 
 
 object JsonSchemaChecker {

--- a/test/uk/gov/hmrc/eusubsidycompliancestub/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancestub/controllers/SubsidyControllerSpec.scala
@@ -16,12 +16,11 @@
 
 package uk.gov.hmrc.eusubsidycompliancestub.controllers
 
-import cats.kernel.Comparison.EqualTo
 import play.api.libs.json.{JsString, JsValue, Json}
 import play.api.mvc.Action
 import play.api.test.Helpers._
-import uk.gov.hmrc.eusubsidycompliancestub.models.{NilSubmissionDate, SubsidyRetrieve, SubsidyUpdate, UndertakingSubsidies, UndertakingSubsidyAmendment}
-import uk.gov.hmrc.eusubsidycompliancestub.models.types.{EisSubsidyAmendmentType, SubsidyAmount, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancestub.models.types.{SubsidyAmount, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancestub.models._
 import uk.gov.hmrc.eusubsidycompliancestub.services.Store
 import uk.gov.hmrc.eusubsidycompliancestub.util.TestInstances
 


### PR DESCRIPTION
Summary of changes
* fixes to ensure non-hmrc subsidies are stored correctly in the stub and that the totals are updated to ensure they're correctly reflected in the frontend
* fixed warnings