### PR TITLE
Update time when usage added

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancestub/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/controllers/SubsidyController.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.eusubsidycompliancestub.models.types.{EORI, SubsidyRef, Under
 import uk.gov.hmrc.eusubsidycompliancestub.services.Store
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.time.LocalDate
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
@@ -45,7 +46,7 @@ class SubsidyController @Inject()(
         case _ =>
           val subsidyUpdate: SubsidyUpdate = json.as[SubsidyUpdate]
           val undertakingRef: UndertakingRef = (json \ "undertakingIdentifier").as[UndertakingRef]
-
+          Store.undertakings.updateLastSubsidyUsage(undertakingRef, LocalDate.now())
           getUpdateResponse(undertakingRef, json, subsidyUpdate)
       }
     }

--- a/app/uk/gov/hmrc/eusubsidycompliancestub/services/EisService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/services/EisService.scala
@@ -41,7 +41,7 @@ object EisService {
     val merged = undertaking.copy(
       reference = madeUndertaking.reference,
       industrySectorLimit = SectorLimits.get(undertaking.industrySector),
-      lastSubsidyUsageUpdt = if(lastSubsidyUsageUpdt.isDefined) lastSubsidyUsageUpdt else madeUndertaking.lastSubsidyUsageUpdt
+      lastSubsidyUsageUpdt = lastSubsidyUsageUpdt
     )
     merged
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancestub/services/Store.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/services/Store.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.eusubsidycompliancestub.models.types.{AmendmentType, EORI, Ei
 import uk.gov.hmrc.eusubsidycompliancestub.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancestub.models.{BusinessEntity, BusinessEntityUpdate, NilSubmissionDate, NonHmrcSubsidy, Undertaking, UndertakingSubsidies, UndertakingSubsidyAmendment, Update}
 
+import java.time.LocalDate
 import scala.util.Random
 
 object Store {
@@ -62,6 +63,18 @@ object Store {
             undertakingStore.update(u.reference.get, ed)
           }
       }
+    }
+
+    def updateLastSubsidyUsage(
+                           undertakingRef: UndertakingRef,
+                           lastSubsidyUsageUpdt: LocalDate
+                         ): Unit = {
+        retrieve(undertakingRef).foreach { u =>
+          val updatedUndertaking = u.copy(
+            lastSubsidyUsageUpdt = Some(lastSubsidyUsageUpdt)
+          )
+          undertakingStore.update(u.reference.get, updatedUndertaking)
+        }
     }
 
 


### PR DESCRIPTION
Removes generated 'lastSubsidyUsageUpdt' when one should not be there. As well as updating 'lastSubsidyUsageUpdt' wehn a subsidy is added.