### PR TITLE
ESC-551 upate HmrcSubsidy model to align to v3.0 of the SCP09 spec

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancestub/models/HmrcSubsidy.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/models/HmrcSubsidy.scala
@@ -28,7 +28,8 @@ case class HmrcSubsidy(
   declarantEORI: EORI, // n.b. SCP09 uses looser validation but will stick with ours
   consigneeEORI: EORI,
   taxType: Option[TaxType],
-  amount: Option[SubsidyAmount],
+  hmrcSubsidyAmtGBP: Option[SubsidyAmount],
+  hmrcSubsidyAmtEUR: Option[SubsidyAmount],
   tradersOwnRefUCR: Option[TraderRef]
 )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancestub/services/DataGenerator.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancestub/services/DataGenerator.scala
@@ -148,7 +148,8 @@ object DataGenerator {
       declarantEORI <- genEORI
       consigneeEORI <- genEORI
       taxType <- Gen.option(genTaxType)
-      amount <- Gen.option(genSubsidyAmount)
+      amountGBP <- Gen.option(genSubsidyAmount)
+      amountEUR <- Gen.option(genSubsidyAmount)
       tradersOwnRefUCR <- Gen.option(genTraderRef)
     } yield HmrcSubsidy(
       declarationID,
@@ -157,7 +158,8 @@ object DataGenerator {
       declarantEORI,
       consigneeEORI,
       taxType,
-      amount,
+      amountGBP,
+      amountEUR,
       tradersOwnRefUCR
     )
 
@@ -169,7 +171,7 @@ object DataGenerator {
       hmrcSubsidies <- Gen.listOfN(y, genHmrcSubsidies(r))
     } yield {
       val nonHMRCTotal = SubsidyAmount(nonHmrcSubsidies.map(x => x.nonHMRCSubsidyAmtEUR).sum[BigDecimal])
-      val hmrcTotal = SubsidyAmount(hmrcSubsidies.flatMap(x => x.amount).sum[BigDecimal])
+      val hmrcTotal = SubsidyAmount(hmrcSubsidies.flatMap(x => x.hmrcSubsidyAmtEUR).sum[BigDecimal])
       UndertakingSubsidies(
         r.undertakingIdentifier,
         nonHMRCTotal,


### PR DESCRIPTION
Summary of changes
* replace HMRC subsidy `amount` field with new currency specific amount fields introduced in the latest version of the `SCP09` specification